### PR TITLE
Add proper modules and classes to fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem "sqlite3"
 
 gem "sprockets-rails"
+gem "bullet_train"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-incoming_webhooks.gemspec
+++ b/bullet_train-incoming_webhooks.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "bullet_train-super_scaffolding"
 end

--- a/lib/bullet_train/incoming_webhooks/engine.rb
+++ b/lib/bullet_train/incoming_webhooks/engine.rb
@@ -1,4 +1,5 @@
 require "bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder"
+require "bullet_train/super_scaffolding"
 
 module BulletTrain
   module IncomingWebhooks

--- a/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
+++ b/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
@@ -1,4 +1,5 @@
 require "scaffolding/incoming_webhooks_transformer"
+require "bullet_train/super_scaffolding/scaffolder"
 
 module BulletTrain
   module IncomingWebhooks

--- a/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -1,3 +1,6 @@
+require "scaffolding"
+require "scaffolding/transformer"
+
 class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
   attr_accessor :provider_name
 


### PR DESCRIPTION
Closes #5.

Part of me doesn't want to put `bullet_train` in the Gemfile, but Super Scaffolding was missing a method from that gem (`scaffolding_things_disabled?`), and the tests are running fine on the starter repository with this branch so I left it there.
